### PR TITLE
Add tests to verify behavior of cleaning based on submodule status

### DIFF
--- a/__test__/git-directory-helper.test.ts
+++ b/__test__/git-directory-helper.test.ts
@@ -281,6 +281,65 @@ describe('git-directory-helper tests', () => {
     expect(git.branchDelete).toHaveBeenCalledWith(false, 'local-branch-2')
   })
 
+  const cleanWhenSubmoduleStatusIsFalse =
+    'cleans when submodule status is false'
+
+  it(cleanWhenSubmoduleStatusIsFalse, async () => {
+    // Arrange
+    await setup(cleanWhenSubmoduleStatusIsFalse)
+    await fs.promises.writeFile(path.join(repositoryPath, 'my-file'), '')
+
+    //mock bad submodule
+
+    const submoduleStatus = git.submoduleStatus as jest.Mock<any, any>
+    submoduleStatus.mockImplementation(async (remote: boolean) => {
+      return false
+    })
+
+    // Act
+    await gitDirectoryHelper.prepareExistingDirectory(
+      git,
+      repositoryPath,
+      repositoryUrl,
+      clean,
+      ref
+    )
+
+    // Assert
+    const files = await fs.promises.readdir(repositoryPath)
+    expect(files).toHaveLength(0)
+    expect(git.tryClean).toHaveBeenCalled()
+  })
+
+  const doesNotCleanWhenSubmoduleStatusIsTrue =
+    'does not clean when submodule status is true'
+
+  it(doesNotCleanWhenSubmoduleStatusIsTrue, async () => {
+    // Arrange
+    await setup(doesNotCleanWhenSubmoduleStatusIsTrue)
+    await fs.promises.writeFile(path.join(repositoryPath, 'my-file'), '')
+
+    const submoduleStatus = git.submoduleStatus as jest.Mock<any, any>
+    submoduleStatus.mockImplementation(async (remote: boolean) => {
+      return true
+    })
+
+    // Act
+    await gitDirectoryHelper.prepareExistingDirectory(
+      git,
+      repositoryPath,
+      repositoryUrl,
+      clean,
+      ref
+    )
+
+    // Assert
+
+    const files = await fs.promises.readdir(repositoryPath)
+    expect(files.sort()).toEqual(['.git', 'my-file'])
+    expect(git.tryClean).toHaveBeenCalled()
+  })
+
   const removesLockFiles = 'removes lock files'
   it(removesLockFiles, async () => {
     // Arrange


### PR DESCRIPTION

**Commit Description:** 

This commit adds tests to verify the behavior of the `gitDirectoryHelper.prepareExistingDirectory()` function when the submodule status is either true or false. 

The test `cleanWhenSubmoduleStatusIsFalse` verifies that the function will clean the directory when the submodule status is false. The test sets up a mock implementation of `git.submoduleStatus` to always return false, writes a file to the repository, and then calls `gitDirectoryHelper.prepareExistingDirectory()`. The test verifies that the directory is cleaned and that `git.tryClean()` is called.

The test `doesNotCleanWhenSubmoduleStatusIsTrue` verifies that the function will not clean the directory when the submodule status is true. The test sets up a mock implementation of `git.submoduleStatus` to always return true, writes a file to the repository, and then calls `gitDirectoryHelper.prepareExistingDirectory()`. The test verifies that the directory is not cleaned, that the file and `.git` folder are present, and that `git.tryClean()` is called.

These tests ensure that the function behaves as expected based on the submodule status.

